### PR TITLE
Prepare for release 0.1.0-v6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	kmodules.xyz/client-go v0.25.12
 	kmodules.xyz/offshoot-api v0.25.0
 	sigs.k8s.io/yaml v1.3.0
-	stash.appscode.dev/apimachinery v0.26.0
+	stash.appscode.dev/apimachinery v0.27.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -898,5 +898,5 @@ sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kF
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
-stash.appscode.dev/apimachinery v0.26.0 h1:74H87DYEMFUO6vesQARIaiXG9N6wSyakTzSoJhBRJZ0=
-stash.appscode.dev/apimachinery v0.26.0/go.mod h1:SLknx4Og4nrUflEJIQF5gjolXmetqXrpisoDlFNV2DI=
+stash.appscode.dev/apimachinery v0.27.0 h1:3Ldo0ncYnsRT4VukSrawan0jWjc+D/nss1yAyDjWj8A=
+stash.appscode.dev/apimachinery v0.27.0/go.mod h1:0bPMB3d0+3oR2hBqFeZyskBDEO5CyWnkHNV+Gp67bMA=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -664,7 +664,7 @@ sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.3.0
 ## explicit; go 1.12
 sigs.k8s.io/yaml
-# stash.appscode.dev/apimachinery v0.26.0
+# stash.appscode.dev/apimachinery v0.27.0
 ## explicit; go 1.18
 stash.appscode.dev/apimachinery/apis
 stash.appscode.dev/apimachinery/apis/repositories


### PR DESCRIPTION
ProductLine: Stash
Release: v2023.03.13
Release-tracker: https://github.com/stashed/CHANGELOG/pull/63
Signed-off-by: 1gtm <1gtm@appscode.com>